### PR TITLE
refactor(SprintTimeline): unify task view into single section

### DIFF
--- a/react-vite/src/components/Pages/SprintTimeline/index.jsx
+++ b/react-vite/src/components/Pages/SprintTimeline/index.jsx
@@ -162,16 +162,6 @@ const SprintTimeline = () => {
       });
     });
 
-  // Split tasks into user's tasks and other tasks
-  const { userTasks, otherTasks } = tasks.reduce((acc, task) => {
-    if (task.assignees.includes(currentUser?.id)) {
-      acc.userTasks.push(task);
-    } else {
-      acc.otherTasks.push(task);
-    }
-    return acc;
-  }, { userTasks: [], otherTasks: [] });
-
   const getTaskStyle = (task, startDate, endDate) => {
     const totalDays = days.length;
     const startDay = days.findIndex(day => isSameDay(day, startDate));
@@ -237,19 +227,10 @@ const SprintTimeline = () => {
         </div>
 
         <div className={styles.contentWrapper}>
-          {userTasks.length > 0 && (
-            <div className={styles.tasksSection}>
-              <h3 className={styles.sectionTitle}>Your Tasks</h3>
-              {userTasks.map(renderTask)}
-            </div>
-          )}
-
-          {otherTasks.length > 0 && (
-            <div className={styles.tasksSection}>
-              <h3 className={styles.sectionTitle}>Team Tasks</h3>
-              {otherTasks.map(renderTask)}
-            </div>
-          )}
+          <div className={styles.tasksSection}>
+            <h3 className={styles.sectionTitle}>Sprint Tasks</h3>
+            {tasks.map(renderTask)}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Remove separation between "Your Tasks" and "Team Tasks"
- Consolidate task rendering into unified "Sprint Tasks" section
- Keep team member color-coding for visual distinction
- Remove unnecessary task filtering logic

This change simplifies the timeline view while maintaining task ownership visibility through color-coding.